### PR TITLE
snapshot can hangup at load time -> fixed

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
     name: snapshot
-    version: 1.5.5
+    version: 1.5.6
 source:
 #    git_tag: 0.9.1
 #    git_url: https://github.com/channelaccess/snapshot.git

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'Readme.md')).read()
 
 setup(name='snapshot',
-      version='1.5.5',
+      version='1.5.6',
       description="Tool for saving and restoring snapshots of EPICS channels",
       long_description=README,
       author='Paul Scherrer Institute',

--- a/src/gui/compare.py
+++ b/src/gui/compare.py
@@ -245,7 +245,7 @@ class SnapshotPvTableView(QtGui.QTableView):
         :param mode_idx1:
         :return:
         """
-        
+
         super().dataChanged(mode_idx, mode_idx1)
         self.viewport().update()
 

--- a/src/gui/restore.py
+++ b/src/gui/restore.py
@@ -140,7 +140,8 @@ class SnapshotRestoreWidget(QtGui.QWidget):
 
                     if reply != QtGui.QMessageBox.No:
                         # Force restore
-                        status, pvs_status = self.snapshot.restore_pvs(pvs_to_restore, callback=self.restore_done_callback, force=True)
+                        status, pvs_status = self.snapshot.restore_pvs(pvs_to_restore,
+                                                                       callback=self.restore_done_callback, force=True)
 
                         # If here restore started successfully. Waiting for callbacks.
 
@@ -162,7 +163,7 @@ class SnapshotRestoreWidget(QtGui.QWidget):
                     self.restore_all_button.setEnabled(True)
                     self.restore_button.setEnabled(True)
 
-                # else: ActionStatus.ok  --> waiting for callbacks
+                    # else: ActionStatus.ok  --> waiting for callbacks
 
             else:
                 # Problem reading data from file
@@ -400,12 +401,12 @@ class SnapshotRestoreFileSelector(QtGui.QWidget):
             meta_data = modified_data["meta_data"]
             labels = meta_data.get("labels", list())
             comment = meta_data.get("comment", "")
-            time = datetime.datetime.fromtimestamp(modified_data.get("modif_time", 0)).strftime('%Y/%m/%d %H:%M:%S')
+            time_ = datetime.datetime.fromtimestamp(modified_data.get("modif_time", 0)).strftime('%Y/%m/%d %H:%M:%S')
 
             # check if already on list (was just modified) and modify file
             # selector
             if modified_file not in self.file_list:
-                selector_item = QtGui.QTreeWidgetItem([time, modified_file, comment, " ".join(labels)])
+                selector_item = QtGui.QTreeWidgetItem([time_, modified_file, comment, " ".join(labels)])
                 self.file_selector.addTopLevelItem(selector_item)
                 self.file_list[modified_file] = modified_data
                 self.file_list[modified_file]["file_selector"] = selector_item
@@ -450,7 +451,7 @@ class SnapshotRestoreFileSelector(QtGui.QWidget):
 
                 # Modify visual representation
                 item_to_modify = modified_file_ref["file_selector"]
-                item_to_modify.setText(0, time)
+                item_to_modify.setText(0, time_)
                 item_to_modify.setText(2, comment)
                 item_to_modify.setText(3, " ".join(labels))
         self.filter_input.update_labels()

--- a/src/gui/snapshot_gui.py
+++ b/src/gui/snapshot_gui.py
@@ -25,7 +25,7 @@ class SnapshotGui(QtGui.QMainWindow):
     thread where core of the application is running
     """
 
-    def __init__(self, req_file_path: str = None, req_file_macros=None, save_dir: str = None, force: bool =False,
+    def __init__(self, req_file_path: str = None, req_file_macros=None, save_dir: str = None, force: bool = False,
                  default_labels: list = None, force_default_labels: bool = None, init_path: str = None,
                  config_path: str = None, parent=None):
         """
@@ -83,8 +83,8 @@ class SnapshotGui(QtGui.QMainWindow):
         self.common_settings["default_labels"] = list(set(default_labels +
                                                           (config.get('labels', dict()).get('labels', list()))))
 
-        self.common_settings["force_default_labels"] = config.get('labels', dict()).get('force-labels', False) or \
-                                                                  force_default_labels
+        self.common_settings["force_default_labels"] = config.get('labels', dict()).get('force-labels', False) \
+                                                       or force_default_labels
 
         # Predefined filters
         self.common_settings["predefined_filters"] = config.get('filters', dict())
@@ -101,9 +101,9 @@ class SnapshotGui(QtGui.QMainWindow):
                 macros_ok = False
 
         if req_file_path is None:
-                req_file_path = ''
+            req_file_path = ''
         if init_path is None:
-                init_path = ''
+            init_path = ''
 
         if not req_file_path or not macros_ok:
             configure_dialog = SnapshotConfigureDialog(self, init_path=os.path.join(init_path, req_file_path),

--- a/src/gui/utils.py
+++ b/src/gui/utils.py
@@ -14,7 +14,7 @@ class SnapshotConfigureDialog(QtGui.QDialog):
     """ Dialog window to select and apply file. """
     accepted = QtCore.pyqtSignal(str, dict)
 
-    def __init__(self, parent=None, init_path=None, init_macros=None,  **kw):
+    def __init__(self, parent=None, init_path=None, init_macros=None, **kw):
         QtGui.QDialog.__init__(self, parent, **kw)
         layout = QtGui.QVBoxLayout()
         layout.setMargin(10)
@@ -364,8 +364,8 @@ class SnapshotKeywordSelectorWidget(QtGui.QComboBox):
         keyword = keyword.strip()
 
         # Skip if already selected or not in predefined labels if defaults_only (force=True overrides defaults_only)
-        if keyword and (keyword not in self.selectedKeywords) and (not self.defaults_only or force or self.defaults_only
-        and keyword in default_labels):
+        if keyword and (keyword not in self.selectedKeywords) and (
+                not self.defaults_only or force or self.defaults_only and keyword in default_labels):
             key_widget = SnapshotKeywordWidget(keyword, self)
             key_widget.delete.connect(self.remove_keyword)
             self.keywordWidgets[keyword] = key_widget


### PR DESCRIPTION
If there is a huge number of constantly changing PVs snapshot hanged at load time, since GUI was not able to show al the changes so quick.

Instead of requesting View part of the gui to update on PV each PV change, this is now done only 5 times per second if there were some PV changes during this time.

Refresh rate is good enough for visualization and cpu load is decreased, therefore application doesn't hang any more.