### PR TITLE
Refactor parsing to improve startup performance

### DIFF
--- a/snapshot/ca_core/snapshot_ca.py
+++ b/snapshot/ca_core/snapshot_ca.py
@@ -427,7 +427,7 @@ class Snapshot(object):
 
 
     @staticmethod
-    def parse_from_save_file(save_file_path):
+    def parse_from_save_file(save_file_path, metadata_only=False):
         """
         Parses save file to dict {'pvname': {'data': {'value': <value>, 'raw_name': <name_with_macros>}}}
 
@@ -458,8 +458,12 @@ class Snapshot(object):
                     # Problem reading metadata
                     err.append('Meta data could not be decoded. Must be in JSON format.')
                 meta_loaded = True
+                if metadata_only:
+                    break
             # skip empty lines and all rest with #
-            elif line.strip() and not line.startswith('#'):
+            elif (not metadata_only
+                  and line.strip()
+                  and not line.startswith('#')):
                 split_line = line.strip().split(',', 1)
                 pvname = split_line[0]
                 if len(split_line) > 1:

--- a/snapshot/gui/compare.py
+++ b/snapshot/gui/compare.py
@@ -454,7 +454,8 @@ class SnapshotPvTableModel(QtCore.QAbstractTableModel):
             macros = file_data["meta_data"].get("macros", dict())
 
         pvs_list_full_names = dict()  # PVS data mapped to real pvs names (no macros)
-        for pv_name_raw, pv_data in file_data["pvs_list"].items():
+        pvs_list, _, _ = self.snapshot.parse_from_save_file(file_data['file_path'])
+        for pv_name_raw, pv_data in pvs_list.items():
             pvs_list_full_names[SnapshotPv.macros_substitution(pv_name_raw, macros)] = pv_data
 
         return pvs_list_full_names

--- a/snapshot/gui/restore.py
+++ b/snapshot/gui/restore.py
@@ -379,15 +379,17 @@ class SnapshotRestoreFileSelector(QtGui.QWidget):
                 if (file_name not in current_files) or \
                         (current_files[file_name]["modif_time"] != os.path.getmtime(file_path)):
 
-                    pvs_list, meta_data, err = self.snapshot.parse_from_save_file(
-                        file_path)
+                    _, meta_data, err = \
+                        self.snapshot.parse_from_save_file(file_path,
+                                                           metadata_only=True)
 
                     # check if we have req_file metadata. This is used to determine which
                     # request file the save file belongs to.
                     # If there is no metadata (or no req_file specified in the metadata)
                     # we search using a prefix of the request file.
                     # The latter is less robust, but is backwards compatible.
-                    if ("req_file_name" in meta_data and meta_data["req_file_name"] == req_file_name) \
+                    if ("req_file_name" in meta_data
+                        and meta_data["req_file_name"] == req_file_name) \
                             or file_name.startswith(req_file_name.split(".")[0] + "_"):
                         # we really should have basic meta data
                         # (or filters and some other stuff will silently fail)
@@ -396,11 +398,10 @@ class SnapshotRestoreFileSelector(QtGui.QWidget):
                         if "labels" not in meta_data:
                             meta_data["labels"] = []
 
-                        # save data (no need to open file again later))
-                        parsed_save_files[file_name] = dict()
-                        parsed_save_files[file_name]["pvs_list"] = pvs_list
-                        parsed_save_files[file_name]["meta_data"] = meta_data
-                        parsed_save_files[file_name]["modif_time"] = os.path.getmtime(file_path)
+                        parsed_save_files[file_name] = {
+                            'meta_data': meta_data,
+                            'modif_time': os.path.getmtime(file_path)
+                        }
 
                         if err:  # report errors only for matching saved files
                             err_to_report.append((file_name, err))

--- a/snapshot/gui/restore.py
+++ b/snapshot/gui/restore.py
@@ -113,8 +113,9 @@ class SnapshotRestoreWidget(QtGui.QWidget):
 
             # Prepare pvs with values to restore
             if file_data:
-                pvs_in_file = file_data.get("pvs_list", None)  # is actually a dict
-                pvs_to_restore = copy.copy(file_data.get("pvs_list", None))  # is actually a dict
+                pvs_in_file, _, _ = \
+                    self.snapshot.parse_from_save_file(file_data['file_path'])
+                pvs_to_restore = copy.copy(pvs_in_file)  # is actually a dict
                 macros = self.snapshot.macros
 
                 if pvs_list is not None:
@@ -399,6 +400,7 @@ class SnapshotRestoreFileSelector(QtGui.QWidget):
                             meta_data["labels"] = []
 
                         parsed_save_files[file_name] = {
+                            'file_path': file_path,
                             'meta_data': meta_data,
                             'modif_time': os.path.getmtime(file_path)
                         }
@@ -445,7 +447,6 @@ class SnapshotRestoreFileSelector(QtGui.QWidget):
                 # Update the global data meta_data info, before checking if
                 # labels_to_remove are used in any of the files.
                 self.file_list[modified_file]["meta_data"] = meta_data
-                self.file_list[modified_file]["pvs_list"] = modified_data["pvs_list"]
 
                 # Check if can be removed (no other file has the same label)
                 if labels_to_remove:

--- a/snapshot/gui/restore.py
+++ b/snapshot/gui/restore.py
@@ -550,8 +550,9 @@ class SnapshotRestoreFileSelector(QtGui.QWidget):
                 settings_window.resize(800, 200)
                 # if OK was pressed, update actual file and reflect changes in the list
                 if settings_window.exec_():
-                    self.snapshot.replace_metadata(self.selected_files[0],
-                                                   self.file_list.get(self.selected_files[0])["meta_data"])
+                    file_data = self.file_list.get(self.selected_files[0])
+                    self.snapshot.replace_metadata(file_data['file_path'],
+                                                   file_data['meta_data'])
                     self.parent.clear_update_files()
             else:
                 QtGui.QMessageBox.information(self, "Information", "Please select one file only",

--- a/snapshot/gui/utils.py
+++ b/snapshot/gui/utils.py
@@ -587,3 +587,24 @@ class DetailedMsgBox(QtGui.QMessageBox):
             textEdit.setSizePolicy(QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Expanding)
 
         return result
+
+
+def show_snapshot_parse_errors(parent, file_and_error_list):
+    err_details = ""
+    for item in file_and_error_list:
+        if item[1]:  # list of errors
+
+            err_details += '- - - ' + item[0] + \
+                            ' - - -\n * '  # file name
+            err_details += '\n * '.join(item[1])
+            err_details += '\n\n'
+
+    err_details = err_details[:-2]  # Remove last two new lines
+
+    if err_details:
+        msg = str(len(file_and_error_list)) + \
+            " of the snapshot saved files (.snap) were loaded with errors " \
+            "(see details)."
+        msg_window = DetailedMsgBox(msg, err_details, 'Warning', parent,
+                                    QtGui.QMessageBox.Ok)
+        msg_window.exec_()


### PR DESCRIPTION
As agreed on the meetings on 24. 01. and 28. 01. 2020, I picked from
the set of proposed changes one with significant impact on the
performance of the snapshot tool.

The goal is reducing the time required for analyzing snapshot files on
program startup. This is achieved by only extracting the metadata of
each snapshot. Loading actual data is defered for later when it is
required to display or restore a snapshot. This also reduces memory
usage as previously, all data was kept in memory, while resources are
now released when data is not viewed anymore.

A side effect of defered loading is that only metadata parsing errors
are caught at startup time while data parsing errors are caught when
the file is loaded. As before, PVs with invalid data are simply
ignored.

During testing, an already existing bug was found and fixed where
editing metadata did not work unless the `cwd` of the program was in
the snapshot directory.

The effect of the change was tested with the `SF_settings` set of
snapshots where most of the snapshots have dates between 20180203
and 20200124. All files and the snapshot tool itself resided on an NFS
share. Measured was total startup time from pressing Return until the
window was displayed. Three cases were considered:

  1. Cache warm, PVs disconnected. Total startup time was reduced from
     38 seconds to 3 seconds. The cache warm case also reflects the
     improvement in the behaviour of the `Refresh` button, which
     completed in about 1 second. Memory usage was decreased from
     4.4 GB to 117 MB. Memory usage increases with the number of
     snapshots selected for comparison, but decreases again when
     snapshots are deselected.

  2. Cache cold (`echo 3 > /proc/sys/vm/drop_caches`), PVs
     disconnected. Startup time was reduced from 65 seconds to 15
     seconds.

  3. Cache cold, 1000 PVs connected and updating at 100 Hz. Startup
     time was 85 seconds before the change and 33 seconds after. When
     running, the GUI was of course sluggish because of high monitor
     rate; this is not affected by this PR.
