### PR TITLE
Poll PV values instead of subscribing to monitors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 .DS_Store
 .pytest_cache
 /build
+snapshot.egg-info

--- a/snapshot/ca_core/snapshot_ca.py
+++ b/snapshot/ca_core/snapshot_ca.py
@@ -13,7 +13,7 @@ from enum import Enum
 
 from epics import PV, ca, dbr
 
-from snapshot.core import SnapshotPv, PvStatus
+from snapshot.core import SnapshotPv, PvStatus, backgroundWorkers
 from snapshot.parser import SnapshotReqFile, parse_macros
 
 import logging
@@ -173,6 +173,7 @@ class Snapshot(object):
         kw["save_time"] = time.time()
         kw["req_file_name"] = os.path.basename(self.req_file_path)
 
+        backgroundWorkers.suspend()
         pvs_data = dict()
         logging.debug("Create snapshot for %d channels" % len(self.pvs.items()))
         for pvname, pv_ref in self.pvs.items():
@@ -187,6 +188,7 @@ class Snapshot(object):
         logging.debug("Writing snapshot to file")
         self.parse_to_save_file(pvs_data, save_file_path, self.macros, symlink_path, **kw)
         logging.debug("Snapshot done")
+        backgroundWorkers.resume()
 
         return ActionStatus.ok, pvs_status
 
@@ -258,6 +260,7 @@ class Snapshot(object):
             return ActionStatus.no_conn, pvs_status
 
         # Do a restore
+        backgroundWorkers.suspend()
         self.restored_pvs_list = list()
         self.restore_callback = callback
         for pvname, pv_ref in self.pvs.items():
@@ -278,6 +281,7 @@ class Snapshot(object):
             self._restore_started = False
             self.restore_callback(status=dict(self.restored_pvs_list), forced=self._current_restore_forced)
             self.restore_callback = None
+            backgroundWorkers.resume()
 
     def restore_pvs_blocking(self, pvs_raw=None, force=False, timeout=10, custom_macros=None):
         """

--- a/snapshot/core.py
+++ b/snapshot/core.py
@@ -57,7 +57,7 @@ class SnapshotPv(PV):
             self.add_conn_callback(connection_callback)
         self.is_array = False
 
-        super().__init__(pvname, connection_callback=self._internal_cnct_callback, auto_monitor=True,
+        super().__init__(pvname, connection_callback=self._internal_cnct_callback, auto_monitor=False,
                          connection_timeout=None, **kw)
 
     def save_pv(self):

--- a/snapshot/core.py
+++ b/snapshot/core.py
@@ -116,8 +116,8 @@ class SnapshotPv(PV):
 
     def get(self, *args, **kwargs):
         """
-        Overriden PV.get() function to provide locking and avoid conflicts
-        with PvUpdater.
+        Overriden PV.get() function. If not arguments are given, returns the
+        cached value if available. See value().
         """
         if args or kwargs:
             return PV.get(self, *args, **kwargs)
@@ -364,6 +364,12 @@ class SnapshotPv(PV):
 
 
 class PvUpdater:
+    """
+    Manages a thread that periodically updated PV values. The values are both
+    cached in the PV objects (see SnapshotPv.value()) and passed to a callback.
+    A normal python thread is used instead of a CAThread because a fresh CA
+    context is needed.
+    """
     updateRate = 1.  # seconds
     _sleep_quantum = 0.1
 

--- a/snapshot/core.py
+++ b/snapshot/core.py
@@ -432,8 +432,8 @@ class PvUpdater:
                 if self._quit:
                     return
 
+            startTime = monotonic()
             with self._lock:
-                startTime = monotonic()
                 if self._suspend:  # this check needs the lock
                     continue
 

--- a/snapshot/core.py
+++ b/snapshot/core.py
@@ -101,6 +101,9 @@ class SnapshotPv(PV):
                          auto_monitor=False,
                          connection_timeout=None, **kw)
 
+    def update_last_value(self, value):
+        self._last_value = value
+
     @PV.value.getter
     def value(self):
         """
@@ -464,6 +467,6 @@ class PvUpdater:
                     self._get_start(ch)
                 vals = [self._get_complete(ch) for ch in chids]
                 for pv, v in zip(pvs, vals):
-                    pv._last_value = v
+                    pv.update_last_value(v)
 
             self._callback(vals)

--- a/snapshot/gui/compare.py
+++ b/snapshot/gui/compare.py
@@ -364,11 +364,19 @@ class ModelUpdater(QtCore.QObject, PvUpdater):
 
     def __init__(self, parent):
         super().__init__(parent=parent, callback=self._callback)
+
+        # Use a blocking connection to throttle the thread.
         self._internal_update.connect(self.update_complete,
-                                      QtCore.Qt.QueuedConnection)
+                                      QtCore.Qt.BlockingQueuedConnection)
 
     def _callback(self, pvs):
         self._internal_update.emit(pvs)
+
+    def stop(self):
+        # The connection is blocking, so disconnect to prevent deadlock
+        # while waiting for thread to finish.
+        self._internal_update.disconnect()
+        PvUpdater.stop(self)
 
 
 class SnapshotPvTableModel(QtCore.QAbstractTableModel):

--- a/snapshot/gui/compare.py
+++ b/snapshot/gui/compare.py
@@ -517,9 +517,9 @@ class SnapshotPvTableModel(QtCore.QAbstractTableModel):
         for value, line in zip(new_values, self._data):
             line.update_pv_value(value)
 
-        # Only update the value column.
+        # Only update the value and comparison columns.
         self.dataChanged.emit(self.createIndex(0, 1),
-                              self.createIndex(len(self._data), 1))
+                              self.createIndex(len(self._data), 2))
 
     def handle_pv_connection_status(self, line_model):
         row = self._data.index(line_model)
@@ -621,6 +621,9 @@ class SnapshotPvTableLine(QtCore.QObject):
         return len(self.data) - 3
 
     def _compare(self, pv_value=None):
+        if pv_value is None and self._pv_ref.connected:
+            pv_value = self._pv_ref.value
+
         n_files = self.get_snap_count()
 
         if n_files == 1 and self._pv_ref.connected and \

--- a/snapshot/gui/compare.py
+++ b/snapshot/gui/compare.py
@@ -388,7 +388,7 @@ class SnapshotPvTableModel(QtCore.QAbstractTableModel):
         self._file_names = list()
 
         self._updater = ModelUpdater(self)
-        self._updater.update_complete.connect(self.handle_pv_update)
+        self._updater.update_complete.connect(self._handle_pv_update)
 
         # Tie starting and stopping the worker thread to starting and
         # stopping of the application.
@@ -513,7 +513,7 @@ class SnapshotPvTableModel(QtCore.QAbstractTableModel):
         elif role == QtCore.Qt.DecorationRole:
             return self._data[index.row()].data[index.column()].get('icon', None)
 
-    def handle_pv_update(self, new_values):
+    def _handle_pv_update(self, new_values):
         for value, line in zip(new_values, self._data):
             line.update_pv_value(value)
 

--- a/snapshot/gui/compare.py
+++ b/snapshot/gui/compare.py
@@ -520,7 +520,6 @@ class SnapshotPvTableLine(QtCore.QObject):
     Model of row in the PV table. Uses SnapshotPv callbacks to update its
     visualization of the PV state.
     """
-    _pv_changed = QtCore.pyqtSignal(dict)
     _pv_conn_changed = QtCore.pyqtSignal(dict)
     data_changed = QtCore.pyqtSignal(QtCore.QObject)
     _DIR_PATH = os.path.dirname(os.path.realpath(__file__))
@@ -537,16 +536,13 @@ class SnapshotPvTableLine(QtCore.QObject):
                      {'icon': None}]  # Compare result
 
         self._conn_clb_id = pv_ref.add_conn_callback(self._conn_callback)
-        self._clb_id = pv_ref.add_callback(self._callback)
 
         # Internal signal
         self._pv_conn_changed.connect(self._handle_conn_callback)
-        self._pv_changed.connect(self._handle_callback)
 
-        # If connected take current value (might missed first callbacks)
         if pv_ref.connected:
             self.conn = pv_ref.connected
-            self.data[1]['data'] = pv_ref.value_as_str()
+            self.data[1]['data'] = ''
             self.data[1]['icon'] = None
 
         else:
@@ -561,7 +557,6 @@ class SnapshotPvTableLine(QtCore.QObject):
         :return:
         """
         self._pv_ref.remove_conn_callback(self._conn_clb_id)
-        self._pv_ref.remove_callback(self._clb_id)
 
     def append_snap_value(self, value):
         if value is not None:
@@ -632,9 +627,7 @@ class SnapshotPvTableLine(QtCore.QObject):
             # dump other values
             return json.dumps(value)
 
-    def _callback(self, **kwargs):
-        self._pv_changed.emit(kwargs)
-
+    # TODO: unused without PV monitors, refactor after polling is added.
     def _handle_callback(self, data):
 
         pv_value = data.get('value', '')

--- a/snapshot/gui/compare.py
+++ b/snapshot/gui/compare.py
@@ -373,9 +373,9 @@ class ModelUpdater(QtCore.QObject, PvUpdater):
 
 class SnapshotPvTableModel(QtCore.QAbstractTableModel):
     """
-    Model of the PV table. Handles adding and removing PVs (rows) and snapshot files (columns).
-    Each row (PV) is represented with SnapshotPvTableLine object. It doesnt emmit dataChange() on each
-    PV change, but rather 5 times per second if some PVs have changed in this time. This increases performance.
+    Model of the PV table. Handles adding and removing PVs (rows)
+    and snapshot files (columns). Each row (PV) is represented with
+    SnapshotPvTableLine object.
     """
 
     file_parse_errors = QtCore.pyqtSignal(list)
@@ -529,7 +529,8 @@ class SnapshotPvTableModel(QtCore.QAbstractTableModel):
 class SnapshotPvTableLine(QtCore.QObject):
     """
     Model of row in the PV table. Uses SnapshotPv callbacks to update its
-    visualization of the PV state.
+    visualization of the PV state. The value is updated by the parent (i.e.
+    SnapshotPvTableModel).
     """
     _pv_conn_changed = QtCore.pyqtSignal(dict)
     _DIR_PATH = os.path.dirname(os.path.realpath(__file__))

--- a/snapshot/gui/compare.py
+++ b/snapshot/gui/compare.py
@@ -666,10 +666,10 @@ class SnapshotPvFilterProxyModel(QSortFilterProxyModel):
         self._name_filter = ''  # string or regex object
         self._eq_filter = PvCompareFilter.show_all
         self._filtered_pvs = list()
-    
+
     def setSourceModel(self, model):
         super().setSourceModel(model)
-        self.sourceModel().dataChanged.connect(self.apply_filter)
+        self.sourceModel().modelReset.connect(self.apply_filter)
 
     def set_name_filter(self, srch_filter):
         self._name_filter = srch_filter

--- a/snapshot/gui/compare.py
+++ b/snapshot/gui/compare.py
@@ -512,7 +512,10 @@ class SnapshotPvTableModel(QtCore.QAbstractTableModel):
 
     def _handle_pv_update(self, new_values):
         for value, line in zip(new_values, self._data):
-            line.update_pv_value(value)
+            # PvUpdater may reconnect faster, so if we are not connected yet,
+            # ignore the update.
+            if line.conn:
+                line.update_pv_value(value)
 
         # Only update the value and comparison columns.
         self.dataChanged.emit(self.createIndex(0, 1),

--- a/snapshot/gui/restore.py
+++ b/snapshot/gui/restore.py
@@ -16,6 +16,7 @@ from PyQt5.QtWidgets import QWidget, QVBoxLayout, QPushButton, QHBoxLayout, QMes
     QMenu, QLineEdit, QLabel
 
 from ..ca_core import PvStatus, ActionStatus, SnapshotPv
+from ..core import backgroundWorkers
 from .utils import SnapshotKeywordSelectorWidget, SnapshotEditMetadataDialog, \
     DetailedMsgBox, show_snapshot_parse_errors
 
@@ -361,6 +362,7 @@ class SnapshotRestoreFileSelector(QWidget):
         # Parses all new or modified files. Parsed files are returned as a
         # dictionary.
         import glob
+        backgroundWorkers.suspend()
         parsed_save_files = dict()
         err_to_report = list()
         req_file_name = os.path.basename(self.common_settings["req_file_path"])
@@ -400,6 +402,7 @@ class SnapshotRestoreFileSelector(QWidget):
                         if err:  # report errors only for matching saved files
                             err_to_report.append((file_name, err))
 
+        backgroundWorkers.resume()
         return parsed_save_files, err_to_report
 
     def update_file_list_selector(self, modif_file_list):

--- a/snapshot/gui/snapshot_gui.py
+++ b/snapshot/gui/snapshot_gui.py
@@ -15,7 +15,7 @@ from PyQt5.QtWidgets import QApplication, QStatusBar, QLabel, QVBoxLayout, QPlai
     QDialog, QSplitter, QCheckBox, QAction, QMenu, QMainWindow
 
 from snapshot.ca_core import Snapshot, parse_macros
-from snapshot.core import SnapshotError
+from snapshot.core import SnapshotError, backgroundWorkers
 from snapshot.parser import ReqParseError, MacroError
 from .compare import SnapshotCompareWidget
 from .restore import SnapshotRestoreWidget
@@ -231,7 +231,9 @@ class SnapshotGui(QMainWindow):
         configure_dialog.exec_()  # Do not act on rejected
 
     def change_req_file(self, req_file_path, macros):
+        backgroundWorkers.suspend()
         self.status_bar.set_status("Loading new request file ...", 0, "orange")
+
         self.set_request_file(req_file_path, macros)
         self.init_snapshot(req_file_path, macros)
 
@@ -243,6 +245,7 @@ class SnapshotGui(QMainWindow):
         self.setWindowTitle(os.path.basename(req_file_path) + ' - Snapshot')
 
         self.status_bar.set_status("New request file loaded.", 3000, "#64C864")
+        backgroundWorkers.resume()
 
     def handle_saved(self):
         # When save is done, save widget is updated by itself


### PR DESCRIPTION
As agreed in the meeting on 06. 02. 2020, I replaced PV monitor
callbacks with periodic polling.

The polling is done by a background thread using the low-level
`epics.ca` API in order to fetch the values in parallel. This thread
is suspended during long-running blocking operations such as save,
restore, and loading a different request file. The polling period is
hardcoded to 1 second, matching the existing hardcoded limit to GUI
updates. It also naturally slows down if updates take a long time.

Once the CA threads were not busy with monitor callbacks, it turned
out that the `SnapshotPvFilterProxyModel` was too slow. It used to
reset completely on every update. This was fixed by letting the base
class handle the update.

Tests were done with 10000 scalar PVs emitting monitors at 100 Hz;
monitor rate is no longer relevant, though. The update period was
slighty lower than 1 second because fetching this many PVs takes
longer than that. After the values are available, the GUI update took
0.10 seconds with 25 PVs visible in the comparion widget with no
snapshots selected for comparison, and 0.17 seconds with comparison
enabled. Such a fast update means very little GUI stuttering.

Large waveforms behave less favorably. The case of
`DBPM-aramis_ac-phase_highq.req` is not problematic, but
`lasercams.req` with its `NELM=7000` waveforms introduces noticeable
stuttering. The GUI becomes uncomfortable, but can be used.

Part of the reason lies in string conversions: to determine whether a
PV value has changed and for comparison to snapshots, the value is
converted to a string, which is an intensive operation for a large
array. Comparisons should instead be done on the `numpy` level. The
other reason is that the Qt widget is slow handling strings of such
length, a problem that worsens as more snapshot files are
selected. This PR does *not fix* either of these issues because there
are future changes planned dealing with exactly this.

This PR does not noticeably affect memory usage.
