### PR TITLE
Improvements to error handling on save and background pvget

### DIFF
--- a/snapshot/core.py
+++ b/snapshot/core.py
@@ -96,9 +96,12 @@ class SnapshotPv(PV):
         if connection_callback:
             self.add_conn_callback(connection_callback)
         self.is_array = False
+
+        # Internals for synchronization with PvUpdater
         self._last_value = None
         self._initialized = False
         self._pvget_lock = Lock()
+        self._pvget_completer = None
 
         super().__init__(pvname,
                          connection_callback=self._internal_cnct_callback,
@@ -116,36 +119,27 @@ class SnapshotPv(PV):
         value = self._last_value  # it could be updated in the background
         if not self._initialized:
             self._initialized = True
-            with self._pvget_lock:
-                value = PV.get(self)
-                self._last_value = value
+            value = self.get(use_monitor=False)
+            self._last_value = value
         return value
 
     def get(self, *args, **kwargs):
         """
         Overriden PV.get() function. If not arguments are given, returns the
         cached value, otherwise calls PV.get(). See also SnapshotPv.value().
-        Positional arguments are not allowed. The following keyword arguments
-        are allowed: use_monitor.
         """
 
-        # Because PvUpdater uses low-level ca calls that can time out,
-        # PV.get() must be able to handle incomplete gets that it
-        # didn't start itself. Thus, all calls to ca.get() in
-        # PvUpdater and PV.get() must be compatible in terms of which
-        # data is fetched. Thus, if any other keyword arguments are
-        # needed, they need to be handled explicitly.
-
-        allowed_kw = ('use_monitor',)
-
-        if args:
-            raise RuntimeError("Positional arguments not allowed.")
-
-        if kwargs:
-            for k in kwargs.keys():
-                if k not in allowed_kw:
-                    raise RuntimeError(f"Keyword argument {k} not allowed.")
+        if args or kwargs:
+            # Because PvUpdater uses low-level ca calls that can time
+            # out, get() must be able to handle incomplete gets that
+            # it didn't start itself.
             with self._pvget_lock:
+                if self._pvget_completer is not None:
+                    val = self._pvget_completer()
+                    if val is None:
+                        # There is never an infinite timeout. If this call
+                        # timed out as well, we still can't proceed.
+                        return None
                 return PV.get(self, *args, **kwargs)
 
         return self.value
@@ -432,26 +426,28 @@ class PvUpdater:
         with self._lock:
             self._pvs = list(pvs)
 
-    def _get_start(self, pv):
+    @staticmethod
+    def _get_start(pv):
         try:
             if pv.connected:
-                # Use get_with_metadata with explicit ftype. This is what
-                # PV.get() does and this call must match that. If that is not
-                # the case and if the get times out, the next call to PV.get()
-                # will crash.
-                ca.get_with_metadata(pv.chid, wait=False, as_numpy=True,
-                                     ftype=pv.ftype)
+                ca.get_with_metadata(pv.chid, wait=False, as_numpy=True)
+                # To be used by SnapshotPv.get() in case we time out.
+                pv._pvget_completer = \
+                    lambda: PvUpdater._get_complete(pv, wait=True)
         except ca.ChannelAccessException:
             pass
 
-    def _get_complete(self, pv):
+    @staticmethod
+    def _get_complete(pv, wait=False):
         try:
             if pv.connected:
+                timeout = PvUpdater.updateRate if wait is False else None
                 md = ca.get_complete_with_metadata(pv.chid, as_numpy=True,
-                                                   ftype=pv.ftype,
-                                                   timeout=self.updateRate)
+                                                   timeout=timeout)
                 if md is None:
                     return None
+                pv._pvget_completer = None
+                pv._last_value = md['value']
                 return md['value']
             else:
                 return None
@@ -475,11 +471,8 @@ class PvUpdater:
                 for pv in self._pvs:
                     pv._pvget_lock.acquire()
                     self._get_start(pv)
-
                 vals = [self._get_complete(pv) for pv in self._pvs]
-
-                for pv, v in zip(self._pvs, vals):
-                    pv._last_value = v
+                for pv in self._pvs:
                     pv._pvget_lock.release()
 
             self._callback(vals)

--- a/snapshot/core.py
+++ b/snapshot/core.py
@@ -165,7 +165,7 @@ class SnapshotPv(PV):
             # Must be after connection test. If checking access when not
             # connected pyepics tries to reconnect which takes some time.
             if self.read_access:
-                saved_value = self.get()
+                saved_value = self.get(use_monitor=False)
                 if self.is_array:
                     if numpy.size(saved_value) == 0:
                         # Empty array is equal to "None" scalar value

--- a/snapshot/core.py
+++ b/snapshot/core.py
@@ -97,6 +97,7 @@ class SnapshotPv(PV):
             self.add_conn_callback(connection_callback)
         self.is_array = False
         self._last_value = None
+        self._initialized = False
         self._pvget_lock = Lock()
 
         super().__init__(pvname,
@@ -113,9 +114,11 @@ class SnapshotPv(PV):
         updates. If no value was fetched yet, do a get().
         """
         value = self._last_value  # it could be updated in the background
-        if value is None:
+        if not self._initialized:
+            self._initialized = True
             with self._pvget_lock:
-                return PV.get(self)
+                value = PV.get(self)
+                self._last_value = value
         return value
 
     def get(self, *args, **kwargs):

--- a/snapshot/gui/save.py
+++ b/snapshot/gui/save.py
@@ -180,21 +180,27 @@ class SnapshotSaveWidget(QWidget):
 
     def save_done(self, status, forced):
         # Enable save button, and update status widgets
-        error = False
+        success = True
         msgs = list()
         msg_times = list()
         status_txt = ""
         status_background = ""
         for pvname, sts in status.items():
-            if sts == PvStatus.access_err:
-                error = not forced  # if here and not in force mode, then this is error state
-                msgs.append("WARNING: {}: Not saved (no connection or no read access)".format(pvname))
+            if sts != PvStatus.ok:
+                if sts == PvStatus.access_err:
+                    # if here and not in force mode, then this is error state
+                    success = success and not forced
+                    msgs.append("WARNING: {}: Not saved (no connection or no read access)".format(pvname))
+                else:
+                    success = False
+                    msgs.append("WARNING: {}: Not saved, error status {}."
+                                .format(pvname, sts))
                 msg_times.append(time.time())
                 status_txt = "Save error"
                 status_background = "#F06464"
         self.sts_log.log_msgs(msgs, msg_times)
 
-        if not error:
+        if success:
             self.sts_log.log_msgs("Save finished.", time.time())
             status_txt = "Save done"
             status_background = "#64C864"


### PR DESCRIPTION
Based on Jira report `CTRLIT-7854`, I changed a couple of things based on my best guess as to what could be the source of the issue.

- When saving a snapshot, a `get()` is done for every PV, ensuring that the value is current.
- If an error occurs getting a fresh value when saving, the status bar becomes red and the errors are available in the status log. No value is stored in the snapshot file.
- During a background update, timeouts can occur. Before, such a PV was skipped during update, so the GUI showed stale value. This was based on the premise that such an error is temporary. The issue reported on Jira sounds like a more permanent connection problem that is masked by such behaviour. Now, the GUI will show an empty value if an update times out.
- The background thread held its own connections to channels in order to work around a bad interaction between `PV` and `ca` APIs. Now, the same ca context is used for both threads and a different workaround is in place. This ensures that the connection status shown in the GUI is all there is to know. More information in the log of commit ef3c0e553a6479441e225922f47883bab8de769b.