### PR TITLE
Gui tweaks and bug fixes

### DIFF
--- a/snapshot/cmd/snapshot_cmd.py
+++ b/snapshot/cmd/snapshot_cmd.py
@@ -88,7 +88,7 @@ def restore(saved_file_path, force=False, timeout=10):
     if status == ActionStatus.ok:
         for pv_name, pv_status in pvs_status.items():
             if pv_status == PvStatus.access_err:
-                logging.warning('\"{}\": Not restored. No connection or no read access.'.format(pv_name))
+                logging.warning('\"{}\": Not restored. No connection or no write access.'.format(pv_name))
 
         logging.info('Snapshot file was restored.')
 
@@ -96,7 +96,7 @@ def restore(saved_file_path, force=False, timeout=10):
         # In case when no response from some PVs after values were pushed.
         for pv_name, pv_status in pvs_status.items():
             if pv_status == PvStatus.access_err:
-                logging.warning('\"{}\": Not restored. No connection or no read access.'.format(pv_name))
+                logging.warning('\"{}\": Not restored. No connection or no write access.'.format(pv_name))
 
         logging.error('Not finished in timeout: {} s. Some PVs may not be restored. Try to increase'
                       ' timeout.'.format(timeout))
@@ -104,6 +104,6 @@ def restore(saved_file_path, force=False, timeout=10):
     else:
         for pv_name, pv_status in pvs_status.items():
             if pv_status == PvStatus.access_err:
-                logging.error('\"{}\": No connection or no read access.'.format(pv_name))
+                logging.error('\"{}\": No connection or no write access.'.format(pv_name))
 
         logging.error('Snapshot file was not restored.')

--- a/snapshot/gui/restore.py
+++ b/snapshot/gui/restore.py
@@ -524,9 +524,11 @@ class SnapshotRestoreFileSelector(QWidget):
                         os.remove(file_path)
                         self.file_list.pop(selected_file)
                         self.pvs = dict()
+                        items = self.file_selector.findItems(
+                            selected_file, Qt.MatchCaseSensitive,
+                            FileSelectorColumns.filename)
                         self.file_selector.takeTopLevelItem(
-                            self.file_selector.indexOfTopLevelItem(self.file_selector.findItems(
-                                selected_file, Qt.MatchCaseSensitive, 1)[0]))
+                            self.file_selector.indexOfTopLevelItem(items[0]))
 
                     except OSError as e:
                         warn = "Problem deleting file:\n" + str(e)

--- a/snapshot/gui/restore.py
+++ b/snapshot/gui/restore.py
@@ -227,7 +227,7 @@ class SnapshotRestoreWidget(QWidget):
         for pvname, sts in status.items():
             if sts == PvStatus.access_err:
                 error = not forced  # if here and not in force mode, then this is error state
-                msgs.append("WARNING: {}: Not restored (no connection or no read access).".format(pvname))
+                msgs.append("WARNING: {}: Not restored (no connection or no write access).".format(pvname))
                 msg_times.append(time.time())
                 status_txt = "Restore error"
                 status_background = "#F06464"

--- a/snapshot/gui/restore.py
+++ b/snapshot/gui/restore.py
@@ -124,7 +124,7 @@ class SnapshotRestoreWidget(QWidget):
         response = QMessageBox.question(self, "Confirm restore",
                                         "Do you wish to restore "
                                         f"{num_pvs} PVs?")
-        if response != QMessageBox.StandardButton.Yes:
+        if response != QMessageBox.Yes:
             return
 
         # Restore can be done only if specific file is selected

--- a/snapshot/gui/restore.py
+++ b/snapshot/gui/restore.py
@@ -321,7 +321,7 @@ class SnapshotRestoreFileSelector(QWidget):
         self.file_selector.setRootIsDecorated(False)
         self.file_selector.setIndentation(0)
         self.file_selector.setColumnCount(len(FileSelectorColumns))
-        column_labels = ["File", "Comment", "Labels"]
+        column_labels = ["File name", "Comment", "Labels"]
         assert(len(column_labels) == len(FileSelectorColumns))
         self.file_selector.setHeaderLabels(column_labels)
         self.file_selector.setAllColumnsShowFocus(True)

--- a/snapshot/gui/save.py
+++ b/snapshot/gui/save.py
@@ -64,7 +64,7 @@ class SnapshotSaveWidget(QWidget):
 
         # Create collapsible group with advanced options,
         # then update output file name and finish adding widgets to layout
-        self.advanced = SnapshotAdvancedSaveSettings("Advanced", self.common_settings, self)
+        self.advanced = SnapshotAdvancedSaveSettings(self.common_settings, self)
 
         self.name_extension = ''
         self.update_name()
@@ -224,44 +224,31 @@ class SnapshotSaveWidget(QWidget):
         self.advanced.update_labels()
 
 
-class SnapshotAdvancedSaveSettings(QGroupBox):
-    def __init__(self, text, common_settings, parent=None):
-        self.parent = parent
+class SnapshotAdvancedSaveSettings(QWidget):
+    def __init__(self, common_settings, parent=None):
+        super().__init__(parent)
 
-        QGroupBox.__init__(self, text, parent)
-        self.setStyleSheet("background-color: rgba(0, 0, 0, 15)")
         min_label_width = 120
-        # frame is a container with all widgets, tat should be collapsed
-        self.frame = QFrame(self)
-        self.frame.setContentsMargins(0, 20, 0, 0)
-        self.frame.setStyleSheet("background-color: None")
-        self.frame.setVisible(True)
-        self.setChecked(True)
 
         layout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self.frame)
         self.setLayout(layout)
-
-        self.frame_layout = QVBoxLayout()
-        self.frame_layout.setContentsMargins(0, 0, 0, 0)
-        self.frame.setLayout(self.frame_layout)
 
         # Make a field to enable user adding a comment
         comment_layout = QHBoxLayout()
         comment_layout.setSpacing(10)
-        comment_label = QLabel("Comment:", self.frame)
+        comment_label = QLabel("Comment:")
         comment_label.setStyleSheet("background-color: None")
         comment_label.setAlignment(Qt.AlignCenter | Qt.AlignRight)
         comment_label.setMinimumWidth(min_label_width)
-        self.comment_input = QLineEdit(self.frame)
+        self.comment_input = QLineEdit()
         comment_layout.addWidget(comment_label)
         comment_layout.addWidget(self.comment_input)
 
         # Make field for labels
         labels_layout = QHBoxLayout()
         labels_layout.setSpacing(10)
-        labels_label = QLabel("Labels:", self.frame)
+        labels_label = QLabel("Labels:")
         labels_label.setStyleSheet("background-color: None")
         labels_label.setAlignment(Qt.AlignCenter | Qt.AlignRight)
         labels_label.setMinimumWidth(min_label_width)
@@ -272,13 +259,8 @@ class SnapshotAdvancedSaveSettings(QGroupBox):
         labels_layout.addWidget(labels_label)
         labels_layout.addWidget(self.labels_input)
 
-        # self.frame_layout.addStretch()
-        self.frame_layout.addLayout(comment_layout)
-        self.frame_layout.addLayout(labels_layout)
+        layout.addLayout(comment_layout)
+        layout.addLayout(labels_layout)
 
     def update_labels(self):
         self.labels_input.update_suggested_keywords()
-
-    def toggle(self):
-        self.frame.setVisible(self.isChecked())
-        self.parent.update_name()

--- a/snapshot/gui/snapshot_gui.py
+++ b/snapshot/gui/snapshot_gui.py
@@ -136,6 +136,8 @@ class SnapshotGui(QMainWindow):
         main_splitter.addWidget(self.compare_widget)
         main_splitter.addWidget(self.status_log)
         main_splitter.setOrientation(Qt.Vertical)
+        main_splitter.setStretchFactor(0, 1)
+        main_splitter.setStretchFactor(1, 3)
 
         # Set default widget and add status bar
         self.setCentralWidget(main_splitter)


### PR DESCRIPTION
User visible changes:
- The crash on restore is fixed, was due to PyQt version differences.
- File access warnings are fixed.
- Snapshot deletion does not crash anymore when dealing with the `*_latest.snap` symlink. When deleting a snapshot, it checks whether the symlink points to it, and deletes the link as well.
- Comparison widget is bigger by default.
- "File" → "File name" column label change (and the corresponding right-click item).
- The save widget no longer has the "Advanced" subgroup.