### PR TITLE
Cleanup, background file scanning, various tweaks and fixes

### DIFF
--- a/snapshot/core.py
+++ b/snapshot/core.py
@@ -15,7 +15,7 @@ _print_trace = False
 def since_start(message=None):
     seconds = '{:.2f}'.format(time() - _start_time)
     if message and _print_trace:
-        print(message, "at", seconds, 's.')
+        print(seconds, message)
     else:
         return seconds
 

--- a/snapshot/core.py
+++ b/snapshot/core.py
@@ -266,20 +266,17 @@ class SnapshotPv(PV):
         else:
             fmt = '{}'
 
-        if is_array:
-            if numpy.size(value) == 0:
-                # Empty array is equal to "None" scalar value
-                return None
-            elif value.shape == tuple():
-                # make scalars as arrays
-                return f'[{fmt}]'.format(value)
-            elif numpy.size(value) > 3:
-                # abbreviate long arrays
-                return f'[{fmt} ... {fmt}]'.format(value[0], value[-1])
-            else:
-                return '[' + ' '.join([fmt.format(x) for x in value]) + ']'
+        if numpy.size(value) == 0:
+            # Empty array is equal to "None" scalar value
+            return None
+        elif value.shape == tuple():
+            # make scalars as arrays
+            return f'[{fmt}]'.format(value)
+        elif numpy.size(value) > 3:
+            # abbreviate long arrays
+            return f'[{fmt} ... {fmt}]'.format(value[0], value[-1])
         else:
-            return fmt.format(value)
+            return '[' + ' '.join([fmt.format(x) for x in value]) + ']'
 
     def compare_to_curr(self, value):
         """

--- a/snapshot/core.py
+++ b/snapshot/core.py
@@ -70,8 +70,9 @@ class _BackgroundWorkers:
             self._workers.append(worker)
 
     def unregister(self, worker):
-        idx = self._workers.index(worker)
-        del self._workers[idx]
+        if worker in self._workers:
+            idx = self._workers.index(worker)
+            del self._workers[idx]
 
 
 background_workers = _BackgroundWorkers()
@@ -419,16 +420,17 @@ class PvUpdater:
         self._quit = False
         self._suspend = False
         self._thread = Thread(target=self._run)
-        background_workers.register(self)
 
     def __del__(self):
-        background_workers.unregister(self)
-        self.stop()
+        if self._thread.is_alive():
+            self.stop()
 
     def start(self):
+        background_workers.register(self)
         self._thread.start()
 
     def stop(self):
+        background_workers.unregister(self)
         self._quit = True
         if self._thread.is_alive():
             self._thread.join()

--- a/snapshot/core.py
+++ b/snapshot/core.py
@@ -323,11 +323,16 @@ class SnapshotPv(PV):
         if value1 is None or value2 is None:
             return value1 is value2
 
-        try:
-            return numpy.allclose(value1, value2, atol=tolerance, rtol=0)
-        except TypeError:
-            # Non-numeric array (i.e. strings)
-            return numpy.array_equal(value1, value2)
+        if is_array:
+            try:
+                return numpy.allclose(value1, value2, atol=tolerance, rtol=0)
+            except TypeError:
+                # Non-numeric array (i.e. strings)
+                return numpy.array_equal(value1, value2)
+        elif isinstance(value1, float) and isinstance(value2, float):
+            return abs(value1 - value2) <= tolerance
+        else:
+            return value1 == value2
 
     def add_conn_callback(self, callback):
         """

--- a/snapshot/core.py
+++ b/snapshot/core.py
@@ -51,14 +51,17 @@ class _BackgroundWorkers:
 
     def suspend(self):
         if self._count == 0:
+            since_start("Pausing background threads")
             for w in self._workers:
                 w.suspend()
+            since_start("Background threads suspended")
         self._count += 1
 
     def resume(self):
         if self._count > 0:
             self._count -= 1
             if self._count == 0:
+                since_start("Resuming background threads")
                 for w in self._workers:
                     w.resume()
 

--- a/snapshot/gui/compare.py
+++ b/snapshot/gui/compare.py
@@ -197,9 +197,8 @@ class SnapshotCompareWidget(QWidget):
         self.model.add_snap_files(selected_files)
         self._proxy.apply_filter()
 
-    def update_shown_files(self, updated_files):
-        self.model.update_snap_files(updated_files)
-        self._proxy.apply_filter()
+    def clear_snap_files(self):
+        self.model.clear_snap_files()
 
     def handle_new_snapshot_instance(self, snapshot):
         self.snapshot = snapshot
@@ -492,25 +491,6 @@ class SnapshotPvTableModel(QtCore.QAbstractTableModel):
 
         self._headers = self._headers[0:PvTableColumns.snapshots]
         self.endRemoveColumns()
-
-    def update_snap_files(self, updated_files):
-        # Check if one of updated files is currently selected, and update
-        # the values if it is.
-        errors = []
-        for file_name in self._headers[PvTableColumns.snapshots:]:
-            file_data = updated_files.get(file_name, None)
-            if file_data is not None:
-                saved_pvs, err = self._replace_macros_on_file_data(file_data)
-                if err:
-                    errors.append((file_data['file_name'], err))
-                idx = self._headers.index(file_name)
-                for pv_line in self._data:
-                    pvname = pv_line.pvname
-                    pv_data = saved_pvs.get(pvname, {"value": None})
-                    pv_line.change_snap_value(idx, pv_data.get("value", None))
-
-        if errors:
-            self.file_parse_errors.emit(errors)
 
     def _replace_macros_on_file_data(self, file_data):
         if self.snapshot.macros:

--- a/snapshot/gui/compare.py
+++ b/snapshot/gui/compare.py
@@ -21,7 +21,7 @@ from PyQt5.QtWidgets import QApplication, QHeaderView, QAbstractItemView, \
 from ..ca_core import Snapshot
 from ..core import SnapshotPv, PvUpdater, process_record
 from ..parser import parse_from_save_file
-from .utils import show_snapshot_parse_errors
+from .utils import show_snapshot_parse_errors, make_separator
 
 import time
 
@@ -137,20 +137,15 @@ class SnapshotCompareWidget(QWidget):
         self.model.change_tolerance(tol.value())
 
         # ### Put all tolerance and filter selectors in one layout
-        def make_separator():
-            sep = QFrame(self)
-            sep.setFrameShape(QFrame.VLine)
-            return sep
-
         filter_layout = QHBoxLayout()
         filter_layout.addWidget(tol_label)
         filter_layout.addWidget(tol)
-        filter_layout.addWidget(make_separator())
+        filter_layout.addWidget(make_separator(self, 'vertical'))
 
         filter_layout.addLayout(pv_filter_layout)
         filter_layout.addWidget(self.regex)
 
-        filter_layout.addWidget(make_separator())
+        filter_layout.addWidget(make_separator(self, 'vertical'))
 
         filter_layout.addWidget(self.compare_filter_inp)
 

--- a/snapshot/gui/compare.py
+++ b/snapshot/gui/compare.py
@@ -213,10 +213,11 @@ class SnapshotCompareWidget(QWidget):
     def _predefined_filter_selected(self, idx):
         txt = self.pv_filter_inp.text()
         if idx == 0:
-            # First empty option
-            pass
+            # First empty option; the menu is always reset to this.
+            return
         if not self.pv_filter_sel.itemIcon(idx).isNull():
-            # Set back to first index, to get rid of the icon. Set to regex and pass text of filter to the input
+            # Set back to first index, to get rid of the icon. Set to regex and
+            # pass text of filter to the input
             self.pv_filter_sel.setCurrentIndex(0)
             self.regex.setChecked(True)
             self.pv_filter_inp.setText(txt)
@@ -225,7 +226,7 @@ class SnapshotCompareWidget(QWidget):
             self.pv_filter_sel.setCurrentIndex(0)
             self.regex.setChecked(False)
             self.pv_filter_inp.setText(txt)
-            
+
     def filter_update(self):
         self._proxy.apply_filter()
 

--- a/snapshot/gui/compare.py
+++ b/snapshot/gui/compare.py
@@ -20,7 +20,7 @@ from PyQt5.QtWidgets import QApplication, QHeaderView, QAbstractItemView, \
 
 from ..ca_core import Snapshot
 from ..core import SnapshotPv, PvUpdater, process_record
-from ..parser import parse_from_save_file
+from ..parser import parse_from_save_file, save_file_suffix
 from .utils import show_snapshot_parse_errors, make_separator
 
 import time
@@ -472,7 +472,9 @@ class SnapshotPvTableModel(QtCore.QAbstractTableModel):
             # Otherwise values of PVs listed in request but not in the saved
             # file are not cleared (value from previous file is seen on the
             # screen)
-            self._headers.append(file_name)
+            prefix = self.parent().common_settings['save_file_prefix']
+            short_name = file_name.lstrip(prefix).rstrip(save_file_suffix)
+            self._headers.append(short_name)
             for pv_line in self._data:
                 pvname = pv_line.pvname
                 pv_data = pvs_list_full_names.get(pvname, {"value": None})

--- a/snapshot/gui/compare.py
+++ b/snapshot/gui/compare.py
@@ -78,11 +78,12 @@ class SnapshotCompareWidget(QWidget):
             self.pv_filter_sel = QComboBox(self)
             self.pv_filter_sel.setEditable(True)
             self.pv_filter_sel.setIconSize(QtCore.QSize(35, 15))
-            sel_layout = QHBoxLayout()
-            sel_layout.addStretch()
-            self.pv_filter_sel.setLayout(sel_layout)
             self.pv_filter_inp = self.pv_filter_sel.lineEdit()
             self.pv_filter_inp.setPlaceholderText("Filter by PV name")
+
+            policy = self.pv_filter_sel.sizePolicy()
+            policy.setHorizontalPolicy(policy.Expanding)
+            self.pv_filter_sel.setSizePolicy(policy)
 
             # Add filters
             self.pv_filter_sel.addItem(None)

--- a/snapshot/gui/restore.py
+++ b/snapshot/gui/restore.py
@@ -176,7 +176,8 @@ class SnapshotRestoreWidget(QWidget):
         # stopping of the application.
         app = QtCore.QCoreApplication.instance()
         app.aboutToQuit.connect(self.scanner.stop)
-        QtCore.QTimer.singleShot(0, self.scanner.start)
+        QtCore.QTimer.singleShot(2 * self.scanner.update_rate * 1000,
+                                 self.scanner.start)
 
     def handle_new_snapshot_instance(self, snapshot, already_parsed_files):
         self.file_selector.handle_new_snapshot_instance(snapshot)

--- a/snapshot/gui/restore.py
+++ b/snapshot/gui/restore.py
@@ -393,7 +393,7 @@ class SnapshotRestoreFileSelector(QWidget):
             self.file_list[new_file]["file_selector"] = selector_item
             new_labels.update(labels)
 
-        self.common_settings["existing_labels"] = new_labels
+        self.common_settings["existing_labels"] = list(new_labels)
         self.filter_input.update_labels()
 
         # Set column sizes

--- a/snapshot/gui/restore.py
+++ b/snapshot/gui/restore.py
@@ -111,7 +111,7 @@ class SnapshotRestoreWidget(QWidget):
     part of the structure "common_settings".
     """
     files_selected = QtCore.pyqtSignal(dict)
-    files_updated = QtCore.pyqtSignal(dict)
+    files_updated = QtCore.pyqtSignal()
     restored_callback = QtCore.pyqtSignal(dict, bool)
 
     def __init__(self, snapshot, common_settings, parent=None, **kw):

--- a/snapshot/gui/snapshot_gui.py
+++ b/snapshot/gui/snapshot_gui.py
@@ -174,11 +174,9 @@ class SnapshotGui(QMainWindow):
 
         # Read snapshots and instantiate PVs in parallel
         def getfiles(*args):
-            since_start("Started parsing snaps")
-            get_save_files(*args)
-            since_start("Finished parsing snaps")
+            return get_save_files(*args)
         future_files = global_thread_pool.submit(getfiles, save_dir,
-                                               req_file_path, {})
+                                                 req_file_path, {})
         self.init_snapshot(req_file_path, macros)
         if self.common_settings['save_dir'] == save_dir:
             already_parsed_files = future_files.result()

--- a/snapshot/gui/snapshot_gui.py
+++ b/snapshot/gui/snapshot_gui.py
@@ -263,11 +263,9 @@ class SnapshotGui(QMainWindow):
             if configure_dialog.exec_() == QDialog.Rejected:
                 self.close()
 
-    def handle_files_updated(self, updated_files):
-        # When new save file is added, or old one has changed, this method
-        # should handle things like updating label widgets and compare widget.
+    def handle_files_updated(self):
         self.save_widget.update_labels()
-        self.compare_widget.update_shown_files(updated_files)
+        self.compare_widget.clear_snap_files()
 
     def handle_selected_files(self, selected_files):
         # selected_files is a dict() with file names as keywords and

--- a/snapshot/gui/snapshot_gui.py
+++ b/snapshot/gui/snapshot_gui.py
@@ -116,13 +116,14 @@ class SnapshotGui(QMainWindow):
 
         self.save_widget = SnapshotSaveWidget(self.snapshot,
                                               self.common_settings, self)
-        self.save_widget.saved.connect(self.handle_saved)
 
         self.restore_widget = SnapshotRestoreWidget(self.snapshot,
                                                     self.common_settings, self)
         self.restore_widget.files_updated.connect(self.handle_files_updated)
 
         self.restore_widget.files_selected.connect(self.handle_selected_files)
+
+        self.save_widget.saved.connect(self.restore_widget.rebuild_file_list)
 
         sr_splitter = QSplitter(self)
         sr_splitter.addWidget(self.save_widget)
@@ -200,11 +201,6 @@ class SnapshotGui(QMainWindow):
         self.status_bar.set_status("New request file loaded.", 3000, "#64C864")
         background_workers.resume()
         since_start("GUI processing finished")
-
-    def handle_saved(self):
-        # When save is done, save widget is updated by itself
-        # Update restore widget (new file in directory)
-        self.restore_widget.rebuild_file_list()
 
     def set_request_file(self, path: str, macros: dict):
         self.common_settings["req_file_path"] = path

--- a/snapshot/gui/snapshot_gui.py
+++ b/snapshot/gui/snapshot_gui.py
@@ -176,7 +176,7 @@ class SnapshotGui(QMainWindow):
         def getfiles(*args):
             return get_save_files(*args)
         future_files = global_thread_pool.submit(getfiles, save_dir,
-                                                 req_file_path, {})
+                                                 req_file_path)
         self.init_snapshot(req_file_path, macros)
         if self.common_settings['save_dir'] == save_dir:
             already_parsed_files = future_files.result()
@@ -187,8 +187,7 @@ class SnapshotGui(QMainWindow):
             future_files.cancel()
             already_parsed_files = get_save_files(
                 self.common_settings['save_dir'],
-                self.common_settings['req_file_path'],
-                {})
+                self.common_settings['req_file_path'])
 
         # handle all gui components
         self.restore_widget.handle_new_snapshot_instance(self.snapshot,
@@ -205,7 +204,7 @@ class SnapshotGui(QMainWindow):
     def handle_saved(self):
         # When save is done, save widget is updated by itself
         # Update restore widget (new file in directory)
-        self.restore_widget.update_files()
+        self.restore_widget.rebuild_file_list()
 
     def set_request_file(self, path: str, macros: dict):
         self.common_settings["req_file_path"] = path

--- a/snapshot/gui/snapshot_gui.py
+++ b/snapshot/gui/snapshot_gui.py
@@ -91,6 +91,12 @@ class SnapshotGui(QMainWindow):
         open_new_req_file_action.setMenuRole(QAction.NoRole)
         open_new_req_file_action.triggered.connect(self.open_new_req_file)
         file_menu.addAction(open_new_req_file_action)
+
+        quit_action = QAction("Quit", file_menu)
+        quit_action.setMenuRole(QAction.NoRole)
+        quit_action.triggered.connect(self.close)
+        file_menu.addAction(quit_action)
+
         menu_bar.addMenu(file_menu)
 
         # Status components are needed by other GUI elements

--- a/snapshot/gui/utils.py
+++ b/snapshot/gui/utils.py
@@ -487,3 +487,11 @@ def show_snapshot_parse_errors(parent, file_and_error_list):
             "(see details)."
         msg_window = DetailedMsgBox(msg, err_details, 'Warning', parent, QMessageBox.Ok)
         msg_window.exec_()
+
+
+def make_separator(parent, direction='vertical'):
+    "Makes a separator line"
+    sep = QFrame(parent)
+    sep.setFrameShape(QFrame.VLine if direction == 'vertical'
+                      else QFrame.HLine)
+    return sep

--- a/snapshot/gui/utils.py
+++ b/snapshot/gui/utils.py
@@ -295,9 +295,10 @@ class SnapshotKeywordSelectorWidget(QComboBox):
         # Method to be called when global list of existing labels (keywords)
         # is changed and widget must be updated.
         self.clear()
-        labels = list() + self.common_settings["default_labels"]
+        labels = self.common_settings['default_labels'][:]
         if not self.defaults_only:
-            labels += self.common_settings["existing_labels"]
+            labels += [l for l in self.common_settings['existing_labels']
+                       if l not in labels]
             self.addItem("")
         else:
             self.addItem("Select labels ...")

--- a/snapshot/parser.py
+++ b/snapshot/parser.py
@@ -1,4 +1,5 @@
-from snapshot.core import SnapshotError, SnapshotPv, global_thread_pool
+from snapshot.core import SnapshotError, SnapshotPv, global_thread_pool, \
+    since_start
 import os
 import re
 import json
@@ -470,6 +471,7 @@ def get_save_files(save_dir, req_file_path, current_files):
     Parses all new or modified files. Parsed files are returned as a
     dictionary.
     """
+    since_start("Started parsing snaps")
     req_file_name = os.path.basename(req_file_path)
     # Check if any file added or modified (time of modification)
     file_dir = os.path.join(save_dir, os.path.splitext(req_file_name)[0])
@@ -520,4 +522,5 @@ def get_save_files(save_dir, req_file_path, current_files):
             if err:
                 err_to_report.append((file_name, err))
 
+    since_start("Finished parsing snaps")
     return parsed_save_files, err_to_report

--- a/snapshot/parser.py
+++ b/snapshot/parser.py
@@ -354,8 +354,13 @@ def parse_from_save_file(save_file_path, metadata_only=False):
     saved_pvs = dict()
     meta_data = dict()  # If macros were used they will be saved in meta_data
     err = list()
-    saved_file = open(save_file_path)
     meta_loaded = False
+
+    try:
+        saved_file = open(save_file_path)
+    except OSError:
+        err.append("File cannot be opened for reading.")
+        return saved_pvs, meta_data, err
 
     for line in saved_file:
         # first line with # is metadata (as json dump of dict)


### PR DESCRIPTION
- Some code cleanup and simplification as a result of coverage testing.
- Fixed duplicated labels.
- Fixed filter menu disappearing.
- Columns are only automatically resized when a request files is loaded, not while the program is running. This fixes inconsistencies and improves performance.
- Periodic background check for snapshot file changes. When a change is detected, the "Refresh" button is colored red. Refresh is not performed automatically to keep code simple and to avoid corner cases (like refresh happening while a right-click menu is open).
- A checkbox can be used to suspend all background tasks (PV and snapshot file scanning).
- A "Quit" menu entry has been added.
- Only the snapshot timestamp is shown in the PV table header, not the whole filename.
- Minor performance improvements.

**Addition**: I just pushed a fix for a reconnect issue. pyepics-3.4 gracefully handles a race condition when a disconnect and reconnect happen during asynchronous caget, where older pyepics versions simply stopped working, silently. But a new type of exception is raised that must be handled by the snapshot tool.