### PR TITLE
Bug fixes: array handling, saving disconnected PVs, restore filtered PVs

### DIFF
--- a/snapshot/ca_core/snapshot_ca.py
+++ b/snapshot/ca_core/snapshot_ca.py
@@ -172,14 +172,20 @@ class Snapshot(object):
         logging.debug("Create snapshot for %d channels" % len(self.pvs.items()))
         for pvname, pv_ref in self.pvs.items():
             # Get current value, status of operation.
-            value, pvs_status[pvname] = pv_ref.save_pv()
+            value, status = pv_ref.save_pv()
 
             # Make data structure with data to be saved
+            pvs_status[pvname] = status
             pvs_data[pvname] = OrderedDict()
             pvs_data[pvname]['raw_name'] = pv_ref.pvname
-            pvs_data[pvname]['egu'] = pv_ref.units
-            pvs_data[pvname]['prec'] = pv_ref.precision
-            pvs_data[pvname]['val'] = value
+            if status == PvStatus.ok or pv_ref.initialized:
+                pvs_data[pvname]['egu'] = pv_ref.units
+                pvs_data[pvname]['prec'] = pv_ref.precision
+                pvs_data[pvname]['val'] = value
+            else:
+                pvs_data[pvname]['egu'] = None
+                pvs_data[pvname]['prec'] = None
+                pvs_data[pvname]['val'] = None
 
         logging.debug("Writing snapshot to file")
         try:

--- a/snapshot/core.py
+++ b/snapshot/core.py
@@ -282,7 +282,8 @@ class SnapshotPv(PV):
                     if numpy.size(saved_value) == 0:
                         # Empty array is equal to "None" scalar value
                         saved_value = None
-                    elif numpy.size(saved_value) == 1:
+                    elif (numpy.size(saved_value) == 1
+                          and not isinstance(saved_value, numpy.ndarray)):
                         # make scalars as arrays
                         saved_value = numpy.asarray([saved_value])
 

--- a/snapshot/core.py
+++ b/snapshot/core.py
@@ -222,6 +222,10 @@ class SnapshotPv(PV):
                          auto_monitor=False,
                          connection_timeout=None, **kw)
 
+    @property
+    def initialized(self):
+        return self._initialized
+
     @PV.value.getter
     def value(self):
         """

--- a/snapshot/core.py
+++ b/snapshot/core.py
@@ -244,7 +244,11 @@ class SnapshotPv(PV):
     def get(self, *args, **kwargs):
         """
         Overriden PV.get() function. If not arguments are given, returns the
-        cached value, otherwise calls PV.get(). See also SnapshotPv.value().
+        cached value, otherwise calls PV.get(). It also makes one-element
+        arrays behave consistently: unless it is given 'as_numpy=False', it
+        will always return an ndarray.
+
+        See also SnapshotPv.value().
         """
 
         if args or kwargs:
@@ -258,7 +262,25 @@ class SnapshotPv(PV):
                         # There is never an infinite timeout. If this call
                         # timed out as well, we still can't proceed.
                         return None
-                return PV.get(self, *args, **kwargs)
+
+                val = PV.get(self, *args, **kwargs)
+
+                # pyepics is inconsistent with regard to one-element arrays;
+                # see _internal_cnct_callback() for explanation. Moreover, it
+                # will return string arrays as lists. To keep everything
+                # uniform, we convert all lists to ndarrays.
+                if val is not None and self.is_array:
+                    if numpy.size(val) == 0:
+                        val = None
+                    elif (numpy.size(val) == 1 and
+                          kwargs.get('as_numpy', True) and
+                          not isinstance(val, numpy.ndarray)):
+                        val = numpy.asarray([val])
+                    elif (kwargs.get('as_numpy', True) and
+                          not isinstance(val, numpy.ndarray)):
+                        val = numpy.asarray(val)
+
+                return val
 
         return self.value
 
@@ -278,15 +300,6 @@ class SnapshotPv(PV):
             # connected pyepics tries to reconnect which takes some time.
             if self.read_access:
                 saved_value = self.get(use_monitor=False)
-                if self.is_array:
-                    if numpy.size(saved_value) == 0:
-                        # Empty array is equal to "None" scalar value
-                        saved_value = None
-                    elif (numpy.size(saved_value) == 1
-                          and not isinstance(saved_value, numpy.ndarray)):
-                        # make scalars as arrays
-                        saved_value = numpy.asarray([saved_value])
-
                 if saved_value is None:
                     logging.debug('No value returned for channel ' + self.pvname)
                     return saved_value, PvStatus.no_value
@@ -332,52 +345,44 @@ class SnapshotPv(PV):
             callback(pvname=self.pvname, status=PvStatus.access_err)
 
     @staticmethod
-    def value_to_display_str(value, is_array, precision):
+    def value_to_display_str(value, precision):
         """
         Get snapshot style string representation of provided value. For display
         purposes only!
 
         :param value: Value to be represented as string.
-        :param is_array: Should be treated as an array.
         :param precision: display precision for floats
 
         :return: String representation of value
         """
 
         # First, check for the most common stuff
-        if not is_array:
-            if isinstance(value, float):
-                if precision and precision > 0:
-                    fmt = f'{{:.{precision}f}}'
-                else:
-                    fmt = '{:f}'
-                return fmt.format(value)
-            elif isinstance(value, str):
-                return value
-            else:
-                return str(value)
-
-        # Use numpy to handle the rest
-        value = numpy.asarray(value)
-        if value.dtype.kind == 'f':
+        if value is None:
+            return ''
+        elif isinstance(value, float):
             if precision and precision > 0:
                 fmt = f'{{:.{precision}f}}'
             else:
                 fmt = '{:f}'
-        else:
-            fmt = '{}'
+            return fmt.format(value)
+        elif isinstance(value, str):
+            return value
+        elif isinstance(value, numpy.ndarray):
+            if value.dtype.kind == 'f':
+                if precision and precision > 0:
+                    fmt = f'{{:.{precision}f}}'
+                else:
+                    fmt = '{:f}'
+            else:
+                fmt = '{}'
 
-        if numpy.size(value) == 0:
-            # Empty array is equal to "None" scalar value
-            return None
-        elif value.shape == tuple():
-            # make scalars as arrays
-            return f'[{fmt}]'.format(value)
-        elif numpy.size(value) > 3:
-            # abbreviate long arrays
-            return f'[{fmt} ... {fmt}]'.format(value[0], value[-1])
+            if numpy.size(value) > 3:
+                # abbreviate long arrays
+                return f'[{fmt} ... {fmt}]'.format(value[0], value[-1])
+            else:
+                return '[' + ' '.join([fmt.format(x) for x in value]) + ']'
         else:
-            return '[' + ' '.join([fmt.format(x) for x in value]) + ']'
+            return str(value)
 
     def compare_to_curr(self, value):
         """
@@ -387,48 +392,31 @@ class SnapshotPv(PV):
 
         :return: Result of comparison.
         """
-        return SnapshotPv.compare(value, self.value, self.is_array, 0.)
+        return SnapshotPv.compare(value, self.value, 0.)
 
     @staticmethod
-    def compare(value1, value2, is_array, tolerance):
+    def compare(value1, value2, tolerance):
         """
         Compare two values snapshot style (handling numpy arrays) for waveforms.
 
         :param value1: Value to be compared to value2.
         :param value2: Value to be compared to value1.
-        :param is_array: Are values to be compared arrays?
         :param tolerance: Comparison is done as |v1 - v2| <= tolerance
 
         :return: Result of comparison.
         """
 
-        if is_array:
-            # Because of how pyepics works, array value can also be sent as scalar (nord=1) and
-            # numpy.size() will return 1
-            # or as (type: epics.dbr.c_double_Array_0) if array is empty --> numpy.size() will
-            # return 0
-
-            if value1 is not None and not isinstance(value1, numpy.ndarray) and numpy.size(value1) == 1:
-                value1 = numpy.array([value1])
-            elif numpy.size(value1) == 0:
-                value1 = None
-
-            if value2 is not None and not isinstance(value2, numpy.ndarray) and numpy.size(value2) == 1:
-                value2 = numpy.array([value2])
-            elif numpy.size(value2) == 0:
-                value2 = None
-
         if value1 is None or value2 is None:
             return value1 is value2
 
-        if is_array:
+        if isinstance(value1, float) and isinstance(value2, float):
+            return abs(value1 - value2) <= tolerance
+        elif any(isinstance(x, numpy.ndarray) for x in (value1, value2)):
             try:
                 return numpy.allclose(value1, value2, atol=tolerance, rtol=0)
             except TypeError:
                 # Non-numeric array (i.e. strings)
                 return numpy.array_equal(value1, value2)
-        elif isinstance(value1, float) and isinstance(value2, float):
-            return abs(value1 - value2) <= tolerance
         else:
             return value1 == value2
 
@@ -543,8 +531,21 @@ class PvUpdater(BackgroundThread):
                 if md is None:
                     return None
                 pv._pvget_completer = None
-                pv._last_value = md['value']
-                return md['value']
+                val = md['value']
+
+                # Handle arrays. See comment in SnapshotPv.get()
+                if val is not None and pv.is_array:
+                    if numpy.size(val) == 0:
+                        val = None
+                    elif (numpy.size(val) == 1 and
+                          not isinstance(val, numpy.ndarray)):
+                        val = numpy.asarray([val])
+                    elif not(isinstance(val, numpy.ndarray)):
+                        val = numpy.asarray(val)
+
+                pv._last_value = val
+                return val
+
             else:
                 return None
         except (ca.ChannelAccessException, ca.ChannelAccessGetFailure):

--- a/snapshot/gui/compare.py
+++ b/snapshot/gui/compare.py
@@ -673,7 +673,6 @@ class SnapshotPvTableLine(QtCore.QObject):
             first_data = self.data[PvTableColumns.snapshots]['raw_value']
             for data in self.data[PvTableColumns.snapshots + 1:]:
                 if not SnapshotPv.compare(first_data, data['raw_value'],
-                                          self.is_array,
                                           self.tolerance_from_precision()):
                     return False
             return True
@@ -683,7 +682,6 @@ class SnapshotPvTableLine(QtCore.QObject):
         if self._pv_ref.connected:
             return SnapshotPv.compare(self._pv_ref.value,
                                       self.data[idx]['raw_value'],
-                                      self.is_array,
                                       self.tolerance_from_precision())
         else:
             return False
@@ -705,7 +703,7 @@ class SnapshotPvTableLine(QtCore.QObject):
             connected = self._pv_ref.connected
             for i in range(1, len(values)):
                 comparison = SnapshotPv.compare(values[i-1], values[i],
-                                                self.is_array, tolerance)
+                                                tolerance)
                 snap = self.data[PvTableColumns.snapshots + i - 1]
                 if connected and not comparison:
                     snap['icon'] = self._NEQ_ICON
@@ -725,9 +723,7 @@ class SnapshotPvTableLine(QtCore.QObject):
             return value
         else:
             # dump other values
-            is_array = isinstance(value, numpy.ndarray) \
-                or isinstance(value, list)
-            return SnapshotPv.value_to_display_str(value, is_array, precision)
+            return SnapshotPv.value_to_display_str(value, precision)
 
     def update_pv_value(self, pv_value):
         value_col = self.data[PvTableColumns.value]
@@ -738,9 +734,7 @@ class SnapshotPvTableLine(QtCore.QObject):
             self._compare(None, get_missing=False)
             return True
 
-        new_value = SnapshotPv.value_to_display_str(pv_value,
-                                                    self.is_array,
-                                                    self.precision)
+        new_value = SnapshotPv.value_to_display_str(pv_value, self.precision)
 
         if unit_col['data'] == 'UNDEF':
             unit_col['data'] = self._pv_ref.units

--- a/snapshot/gui/compare.py
+++ b/snapshot/gui/compare.py
@@ -770,7 +770,7 @@ class SnapshotPvFilterProxyModel(QSortFilterProxyModel):
         self._disconn_filter = True  # show disconnected?
         self._name_filter = ''  # string or regex object
         self._eq_filter = PvCompareFilter.show_all
-        self._filtered_pvs = list()
+        self._filtered_pvs = None
 
     def setSourceModel(self, model):
         super().setSourceModel(model)
@@ -793,6 +793,7 @@ class SnapshotPvFilterProxyModel(QSortFilterProxyModel):
         self._filtered_pvs = list()
         self.invalidate()
         self.filtered.emit(self._filtered_pvs)
+        self._filtered_pvs = None
 
     def filterAcceptsRow(self, idx: int, source_parent: QtCore.QModelIndex):
         """
@@ -836,7 +837,8 @@ class SnapshotPvFilterProxyModel(QSortFilterProxyModel):
                 # Only name and connection filters apply
                 result = name_match and connected_match
 
-        if result:
+        # We only construct the list of PVs when needed by apply_filter()
+        if result and self._filtered_pvs is not None:
             self._filtered_pvs.append(row_model.pvname)
 
         return result

--- a/snapshot/gui/snapshot_gui.py
+++ b/snapshot/gui/snapshot_gui.py
@@ -296,11 +296,11 @@ class SnapshotGui(QMainWindow):
     def _handle_restore_request(self, pvs_list):
         self.restore_widget.do_restore(pvs_list)
 
-    def handle_pvs_filtered(self, pvs=None):
-        if pvs is None:
-            pvs = list()
-
-        self.restore_widget.filtered_pvs = pvs
+    def handle_pvs_filtered(self, pv_names_set):
+        # Yes, this merely sets the reference to the set of names, so
+        # technically, it needn't be done every time. But good luck tracking
+        # down who updated the list without this ;)
+        self.restore_widget.filtered_pvs = pv_names_set
 
 
 # -------- Status widgets -----------

--- a/snapshot/parser.py
+++ b/snapshot/parser.py
@@ -452,27 +452,25 @@ def parse_from_save_file(save_file_path, metadata_only=False):
                     data = json.loads(split_line[1])
                     pv_value = data['val']
                     # EGU and PREC are ignored, only stored for information.
-                    if isinstance(pv_value, list):
-                        if any(isinstance(x, list) for x in pv_value):
-                            # A version of this tool incorrectly wrote
-                            # one-element arrays, and we shouldn't crash if we
-                            # read such a snapshot.
-                            pv_value = None
-                            err.append(f"Value of '{pvname}' contains nested "
-                                       "lists; only one-dimensional arrays "
-                                       "are supported.")
-                        else:
-                            # arrays as numpy array, because pyepics returns
-                            # as numpy array
-                            pv_value = numpy.asarray(pv_value)
                 else:
                     # The legacy "name,value" format
                     pv_value_str = split_line[1]
                     pv_value = json.loads(pv_value_str)
-                    if isinstance(pv_value, list):
+
+                if isinstance(pv_value, list):
+                    if any(isinstance(x, list) for x in pv_value):
+                        # A version of this tool incorrectly wrote
+                        # one-element arrays, and we shouldn't crash if we
+                        # read such a snapshot.
+                        pv_value = None
+                        err.append(f"Value of '{pvname}' contains nested "
+                                   "lists; only one-dimensional arrays "
+                                   "are supported.")
+                    else:
                         # arrays as numpy array, because pyepics returns
                         # as numpy array
                         pv_value = numpy.asarray(pv_value)
+
             except json.JSONDecodeError:
                 pv_value = None
                 err.append(f"Value of '{pvname}' cannot be decoded, ignored.")

--- a/snapshot/parser.py
+++ b/snapshot/parser.py
@@ -452,6 +452,12 @@ def parse_from_save_file(save_file_path, metadata_only=False):
                     data = json.loads(split_line[1])
                     pv_value = data['val']
                     # EGU and PREC are ignored, only stored for information.
+                    if isinstance(pv_value, list) and \
+                       any(isinstance(x, list) for x in pv_value):
+                        pv_value = None
+                        err.append(f"Value of '{pvname}' contains nested "
+                                   "lists; only one-dimensional arrays are "
+                                   "supported.")
                 else:
                     # The legacy "name,value" format
                     pv_value_str = split_line[1]

--- a/snapshot/parser.py
+++ b/snapshot/parser.py
@@ -452,12 +452,19 @@ def parse_from_save_file(save_file_path, metadata_only=False):
                     data = json.loads(split_line[1])
                     pv_value = data['val']
                     # EGU and PREC are ignored, only stored for information.
-                    if isinstance(pv_value, list) and \
-                       any(isinstance(x, list) for x in pv_value):
-                        pv_value = None
-                        err.append(f"Value of '{pvname}' contains nested "
-                                   "lists; only one-dimensional arrays are "
-                                   "supported.")
+                    if isinstance(pv_value, list):
+                        if any(isinstance(x, list) for x in pv_value):
+                            # A version of this tool incorrectly wrote
+                            # one-element arrays, and we shouldn't crash if we
+                            # read such a snapshot.
+                            pv_value = None
+                            err.append(f"Value of '{pvname}' contains nested "
+                                       "lists; only one-dimensional arrays "
+                                       "are supported.")
+                        else:
+                            # arrays as numpy array, because pyepics returns
+                            # as numpy array
+                            pv_value = numpy.asarray(pv_value)
                 else:
                     # The legacy "name,value" format
                     pv_value_str = split_line[1]


### PR DESCRIPTION
## Saving disconnected PVs

When saving a snapshot in the case when some PVs were disconnected from the beginning, attempting to obtain `PREC` and `EGU` caused a get to happen. This caused long delays and has been fixed.

## Array handling

pyepics has a strange behaviour when it sometimes (but apparently not always; it might be version dependent) treats one-element waveforms as scalars. The tool handled this, but the workarounds were sprinkled all over the place and were not always correct. This caused a version of the tool to produce incorrect snapshots that would later cause it to crash when loaded.

- The crash is avoided because waveforms are checked to be one-dimensional when a snapshot is loaded. Thus, existing snapshots can be used, and the error report tells exactly which values need to be corrected in the file.

- The array handling is consolidated so that waveforms are converted to `ndarray` type at the source (on caget and on loading a snapshot). Inner code does not need to know the one-element-array quirk.

## Restoring filtered PVs

The "Restore filtered" button consulted a list of PVs that was only updated when a filter was changed. When filtering was set to "Show equal" or "Show different", the list of PVs could change because their values changed, but the list consulted by the "Restore filtered" button was not updated. This has been fixed; there is a performance cost, but in my testing it was minor.