### PR TITLE
Machine param polish

### DIFF
--- a/snapshot/gui/compare.py
+++ b/snapshot/gui/compare.py
@@ -710,7 +710,10 @@ class SnapshotPvTableLine(QtCore.QObject):
     def tolerance_from_precision(self):
         prec = self.precision
         if not prec or prec < 0:
-            prec = numpy.inf
+            # The default precision is 6, which matches string formatting
+            # behaviour. It makes no sense to do comparison to a higher
+            # precision than what the user can see.
+            prec = 6
         return self._tolerance_f * 10**(-prec)
 
     @staticmethod

--- a/snapshot/gui/restore.py
+++ b/snapshot/gui/restore.py
@@ -492,8 +492,13 @@ class SnapshotRestoreFileSelector(QWidget):
             assert(len(row) == FileSelectorColumns.params)
             param_vals = [None] * len(all_params)
             for p, v in params.items():
+                string = SnapshotPv.value_to_display_str(
+                    v['value'],
+                    v['precision'] if v['precision'] is not None else 0)
+                if v['units']:
+                    string += ' ' + v['units']
                 idx = all_params.index(p)
-                param_vals[idx] = str(v)
+                param_vals[idx] = string
             selector_item = QTreeWidgetItem(row + param_vals)
             self.file_selector.addTopLevelItem(selector_item)
             self.file_list[new_file] = new_data

--- a/snapshot/gui/restore.py
+++ b/snapshot/gui/restore.py
@@ -507,6 +507,14 @@ class SnapshotRestoreFileSelector(QWidget):
         for col in range(self.file_selector.columnCount()):
             self.file_selector.resizeColumnToContents(col)
 
+        # There can be some rather long comments in the snapshots, so let's
+        # make sure that they don't push out more useful stuff.
+        if self.file_selector.columnWidth(FileSelectorColumns.comment) \
+           > self.file_selector.columnWidth(FileSelectorColumns.filename):
+            self.file_selector.setColumnWidth(
+                FileSelectorColumns.comment,
+                self.file_selector.columnWidth(FileSelectorColumns.filename))
+
     def filter_file_list_selector(self):
         file_filter = self.filter_input.file_filter
 

--- a/snapshot/gui/restore.py
+++ b/snapshot/gui/restore.py
@@ -14,7 +14,7 @@ import json
 
 from PyQt5 import QtCore, QtGui
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QCursor, QGuiApplication
+from PyQt5.QtGui import QCursor, QGuiApplication, QPalette, QColor
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QPushButton, QHBoxLayout, \
     QFormLayout, QMessageBox, QTreeWidget, QTreeWidgetItem, QMenu, QLineEdit
 
@@ -865,6 +865,10 @@ class SnapshotFileFilterWidget(QWidget):
         self.param_input.textEdited.connect(self.update_filter)
         right_layout.addRow("Params:", self.param_input)
 
+        self._inp_palette_ok = self.param_input.palette()
+        self._inp_palette_err = QPalette()
+        self._inp_palette_err.setColor(QPalette.Base, QColor("#F39292"))
+
         # File name filter
         self.name_input = QLineEdit(self)
         self.name_input.setPlaceholderText("Filter by name")
@@ -879,10 +883,9 @@ class SnapshotFileFilterWidget(QWidget):
 
     def set_param_input_color(self):
         if self.param_input.hasAcceptableInput():
-            style = ''
+            self.param_input.setPalette(self._inp_palette_ok)
         else:
-            style = 'color: red;'
-        self.param_input.setStyleSheet(style)
+            self.param_input.setPalette(self._inp_palette_err)
 
     def update_filter(self):
         if self.keys_input.get_keywords():

--- a/snapshot/gui/restore.py
+++ b/snapshot/gui/restore.py
@@ -559,8 +559,12 @@ class SnapshotRestoreFileSelector(QWidget):
                     v1, v2 = ensure_nums_or_strings(v1, v2)
                     if isinstance(v2, float):
                         # If precision is defined, compare with tolerance.
+                        # The default precision is 6, which matches string
+                        # formatting behaviour. It makes no sense to do
+                        # comparison to a higher precision than what the user
+                        # can see.
                         prec = file_params[p]['precision']
-                        tol = 10**(-prec) if (prec and prec > 0) else 0
+                        tol = 10**(-prec) if (prec and prec > 0) else 10**-6
                         if abs(v1 - v2) > tol:
                             return False
                     else:

--- a/snapshot/gui/save.py
+++ b/snapshot/gui/save.py
@@ -13,7 +13,7 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QLineEdit, QLabel, QHBoxLayout, QVBoxLayout, QFrame, QGroupBox, QMessageBox, QPushButton, \
     QWidget
 
-from ..core import get_pv_values
+from ..core import get_machine_param_data
 from ..ca_core import PvStatus, ActionStatus
 from ..parser import save_file_suffix
 from .utils import SnapshotKeywordSelectorWidget, DetailedMsgBox
@@ -115,11 +115,9 @@ class SnapshotSaveWidget(QWidget):
             comment = self.advanced.comment_input.text()
 
             machine_params = self.common_settings['machine_params']
-            params = {p: v for p, v in zip(machine_params.keys(),
-                                           get_pv_values(machine_params.values()))}
-
-            invalid_params = {p: v for p, v in params.items()
-                              if type(v) not in (float, int, str)}
+            params_data = get_machine_param_data(machine_params)
+            invalid_params = {p: v['value'] for p, v in params_data.items()
+                              if type(v['value']) not in (float, int, str)}
             if invalid_params:
                 msg = "Some machine parameters have invalid values " \
                     "(see details). Do you want to save anyway?\n"
@@ -135,7 +133,7 @@ class SnapshotSaveWidget(QWidget):
                     self.sts_info.clear_status()
                     return
                 for p in invalid_params:
-                    params[p] = None
+                    params_data[p] = None
 
             force = self.common_settings["force"]
             # Start saving process with default "force" flag and notify when finished
@@ -143,7 +141,7 @@ class SnapshotSaveWidget(QWidget):
                                                         force=force,
                                                         labels=labels,
                                                         comment=comment,
-                                                        machine_params=params,
+                                                        machine_params=params_data,
                                                         symlink_path=os.path.join(
                                                             self.common_settings["save_dir"],
                                                             self.common_settings["save_file_prefix"] +

--- a/snapshot/parser.py
+++ b/snapshot/parser.py
@@ -479,6 +479,16 @@ def parse_from_save_file(save_file_path, metadata_only=False):
 
     if not meta_loaded:
         err.insert(0, 'No meta data in the file.')
+    else:
+        # Check that the snapshot has machine parameters with metadata; at some
+        # point, only values were being saved.
+        for p, v in meta_data.get('machine_params', {}).items():
+            if not isinstance(v, dict):
+                meta_data['machine_params'][p] = {
+                    'value': v,
+                    'units': None,
+                    'precision': None
+                }
 
     saved_file.close()
     return saved_pvs, meta_data, err


### PR DESCRIPTION
- Precision is now honored when displaying and comparing machine parameters.
- EGU of machine parameters is shown in the column headers.
- To support the above, EGU and PREC of machine parameters are stored in snapshots.
  * The EGU shown is from the latest snapshot.
  * The PREC used to match the filter expression is from each snapshot.
- The default PREC (when not provided by PV) is changed to 6; this matches the string formatting behaviour, avoiding surprises when behaviour doesn't match what is on the screen.
- When auto-resizing columns, the "Comment" column width will not exceed the "File name" column.
- The coloring of an invalid machine parameter filter expression now matches existing behavior of the PV name regex filter.