### PR TITLE
Fix crash when force-saving disconnected PVs

### DIFF
--- a/snapshot/gui/save.py
+++ b/snapshot/gui/save.py
@@ -162,7 +162,7 @@ class SnapshotSaveWidget(QWidget):
                                                                 force=True,
                                                                 labels=labels,
                                                                 comment=comment,
-                                                                machine_params=params,
+                                                                machine_params=params_data,
                                                                 symlink_path=os.path.join(
                                                                     self.common_settings["save_dir"],
                                                                     self.common_settings["save_file_prefix"] +


### PR DESCRIPTION
See title, there was a misnamed variable reference.