### PR TITLE
catch exception of unequal length arrays

### DIFF
--- a/snapshot/core.py
+++ b/snapshot/core.py
@@ -446,8 +446,8 @@ class SnapshotPv(PV):
         elif any(isinstance(x, numpy.ndarray) for x in (value1, value2)):
             try:
                 return numpy.allclose(value1, value2, atol=tolerance, rtol=0)
-            except TypeError:
-                # Non-numeric array (i.e. strings)
+            except (TypeError, ValueError):
+                # Array of non-numeric types or with unequal lengths
                 return numpy.array_equal(value1, value2)
         else:
             return value1 == value2


### PR DESCRIPTION
If two arrays are of different lengths, the exception is of ValueError. e.g.
```
>>> import numpy
>>> numpy.allclose([1,2],[1,2,3])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/gfa/python-3.7/latest/lib/python3.7/site-packages/numpy/core/numeric.py", line 2423, in allclose
    res = all(isclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan))
  File "/opt/gfa/python-3.7/latest/lib/python3.7/site-packages/numpy/core/numeric.py", line 2524, in isclose
    return within_tol(x, y, atol, rtol)
  File "/opt/gfa/python-3.7/latest/lib/python3.7/site-packages/numpy/core/numeric.py", line 2510, in within_tol
    return less_equal(abs(x-y), atol + rtol * abs(y))
ValueError: operands could not be broadcast together with shapes (2,) (3,)
```

This could happen if a waveform PV is reconfigured with a different length.